### PR TITLE
Added a better solution to addition() of two list (exercise 10)

### DIFF
--- a/technical.md
+++ b/technical.md
@@ -266,7 +266,7 @@ def mean(numbers):
 **4) STD**. Calculate the standard deviation of elements in a list.
 
 * `std([1, 2, 3, 4]) = 1.29`
-* `std([1]) = NaN`
+* `std([1]) = NaN` (use `float('NaN')`)
 * `std([]) = NaN`
 
 <img src="img/formula_std.png" />
@@ -275,11 +275,11 @@ def mean(numbers):
 from math import sqrt
 
 def std_dev(numbers):
-    if len(numbers) > 0:
+    if len(numbers) > 1:
         avg = mean(numbers)
-        var = sum([(i - avg) ** 2 for i in numbers]) / len(numbers)
-        ans = sqrt(var)
-        return ans
+        var = sum((i - avg) ** 2 for i in numbers) / (len(numbers) - 1)
+        std = sqrt(var)
+        return std
     return float('NaN')
 ```
 
@@ -736,6 +736,7 @@ def deduplication1(lst):
     return ans
 
 def deduplication2(lst):
+    # order is not guaranteed unless call sorted(list(set(lst))) to sort again
     return list(set(lst))
 ```
 
@@ -762,6 +763,7 @@ def intersection1(lst1, lst2):
 
 def intersection2(lst1, lst2):
     '''removes duplicates'''
+    # order is not guaranteed unless call sorted(...) to sort again
     return list(set(lst1) & set(lst2))
 ```
 
@@ -790,6 +792,7 @@ def union1(lst1, lst2):
 
 def union2(lst1, lst2):
     '''removes duplicates'''
+    # order is not guaranteed unless call sorted(...) to sort again
     return list(set(lst1) | set(lst2))
 ```
 
@@ -815,6 +818,22 @@ def addition(lst1, lst2):
         return ans
     val = list_to_int(lst1) + list_to_int(lst2)
     ans = [int(i) for i in str(val)]
+    return ans
+
+# another solution without int() and str() should be helpful
+def addition2(lst1, lst2):
+    if len(lst2) == 0 or lst2 == [0]:
+        return lst1[:]
+    elif len(lst1) == 0:
+        return lst2[:]
+    # lst1, lst2 not empty
+    digit1, lst1rest = lst1[-1], lst1[:-1]
+    digit2, lst2rest = lst2[-1], lst2[:-1]
+    digit, remainder = divmod(digit1 + digit2, 10)
+    lst = addition2(
+        addition2(lst1rest, [digit]),  # recursively add digit to lst1
+        lst2rest)  # and then continue to add lst2
+    ans = lst + [remainder]  # add the remainder as last digit
     return ans
 ```
 


### PR DESCRIPTION
See [the code on PythonTutor.com](http://pythontutor.com/live.html#code=def%20addition2%28lst1,%20lst2%29%3A%0A%20%20%20%20if%20len%28lst2%29%20%3D%3D%200%20or%20lst2%20%3D%3D%20%5B0%5D%3A%0A%20%20%20%20%20%20%20%20return%20lst1%5B%3A%5D%0A%20%20%20%20elif%20len%28lst1%29%20%3D%3D%200%3A%0A%20%20%20%20%20%20%20%20return%20lst2%5B%3A%5D%0A%20%20%20%20%23%20lst1,%20lst2%20not%20empty%0A%20%20%20%20digit1,%20lst1rest%20%3D%20lst1%5B-1%5D,%20lst1%5B%3A-1%5D%0A%20%20%20%20digit2,%20lst2rest%20%3D%20lst2%5B-1%5D,%20lst2%5B%3A-1%5D%0A%20%20%20%20digit,%20remainder%20%3D%20divmod%28digit1%20%2B%20digit2,%2010%29%0A%20%20%20%20lst%20%3D%20addition2%28%0A%20%20%20%20%20%20%20%20addition2%28lst1rest,%20%5Bdigit%5D%29,%0A%20%20%20%20%20%20%20%20lst2rest%29%0A%20%20%20%20ans%20%3D%20lst%20%2B%20%5Bremainder%5D%0A%20%20%20%20return%20ans%0A%0Alst1%20%3D%20%5B1,%201%5D%0Alst2%20%3D%20%5B2%5D%0Aaddition2%28lst1,%20lst2%29%0A%0Alst1%20%3D%20%5B9,%209%5D%0Alst2%20%3D%20%5B2%5D%0Aaddition2%28lst1,%20lst2%29%0A%0Alst1%20%3D%20%5B9,%209,%209,%209,%209,%209,%209,%209,%209,%209%5D%0Alst2%20%3D%20%5B9,%209,%209,%209,%209,%209,%209,%209,%209,%209%5D%0Aprint%28addition2%28lst1,%20lst2%29%29%0A&cumulative=false&curInstr=376&heapPrimitives=nevernest&mode=display&origin=opt-live.js&py=3&rawInputLstJSON=%5B%5D&textReferences=false) to check.

Other changes:
- in the `std` function, should be divided by `(len(numbers) - 1)` and not `len(numbers)` (fixed)
- add warnings in the functions about sorted list: the order is *not* guaranteed unless call sorted(...) to sort again: Python specification does *not* guarantee that `l == list(set(l))`