### PR TITLE
formatting

### DIFF
--- a/contrib/probability.md
+++ b/contrib/probability.md
@@ -16,7 +16,7 @@
 
 You have a probability of 1/500 to draw the special coin and a probably of 499/500 to draw one of the regular coints.
 The probability of 8 consequitves heads is 1 for the special coin and (1/2)^8 for the regular coin.
-Combined, that gives you a 0.2% probability to draw the special coin and flip heads 8 times (1/500*1) and a probability of 0.4% to draw a regular coin and flip heads 8 times (499/500*1/256). Thus, the answer is no. You are not more likely to have drawn the special coin.
+Combined, that gives you a 0.2% probability to draw the special coin and flip heads 8 times (1/500 * 1) and a probability of 0.4% to draw a regular coin and flip heads 8 times (499/500 * 1/256). Thus, the answer is no. You are not more likely to have drawn the special coin.
 
 <br/>
 


### PR DESCRIPTION
The multiplications were originally shown as *italic text* due to markdown formats (the " * " character).